### PR TITLE
Reduce rust market API server container image size

### DIFF
--- a/servers/rust-server/Dockerfile
+++ b/servers/rust-server/Dockerfile
@@ -6,16 +6,23 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN cargo install cargo-chef --version ^0.1
+
 RUN cargo install sccache --version ^0.7
 
 ENV RUSTC_WRAPPER=sccache SCCACHE_DIR=/sccache
 
 FROM base AS planner
+
 WORKDIR /app
+
 COPY Cargo.toml Cargo.lock ./
+
 COPY entity ./entity
+
 COPY migration ./migration
+
 COPY src ./src
+
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     cargo chef prepare --recipe-path recipe.json
@@ -25,31 +32,33 @@ FROM base AS builder
 WORKDIR /build
 
 COPY --from=planner /app/recipe.json recipe.json
+
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     cargo chef cook --release --recipe-path recipe.json
 
 COPY Cargo.toml Cargo.lock ./
+
 COPY templates ./templates
+
 COPY entity ./entity
+
 COPY migration ./migration
+
 COPY src ./src
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     cargo build --release
 
-FROM debian:bookworm-slim
-
-RUN apt-get update && apt-get install -y \
-    ca-certificates \
-    libssl3 \
-    && rm -rf /var/lib/apt/lists/*
+FROM gcr.io/distroless/cc-debian12:nonroot
 
 WORKDIR /app
 
 COPY --from=builder /build/target/release/finwar-market /app/finwar-market
+
 COPY templates ./templates
+
 COPY static ./static
 
 ENV RUST_LOG=info


### PR DESCRIPTION
Switch container running image from debian:bookworm-slim to a distroless equivalent to reduce image size from 117MB to 44MB.
