### PR TITLE
Extend Market API configuration

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,5 +1,5 @@
 POSTGRES_USER=finwar
 POSTGRES_PASSWORD=password
 POSTGRES_DB=finwar
-DATABASE_URL=postgresql://finwar:password@localhost:5432/finwar
+FINWAR_MARKET_DATABASE_URL=postgresql://finwar:password@localhost:5432/finwar
 RUST_LOG=info

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       context: ./servers/rust-server
       dockerfile: docker/Dockerfile
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-finwar}:${POSTGRES_PASSWORD:-password}@timescaledb:5432/${POSTGRES_DB:-finwar}
+      FINWAR_MARKET_DATABASE_URL: postgresql://${POSTGRES_USER:-finwar}:${POSTGRES_PASSWORD:-password}@timescaledb:5432/${POSTGRES_DB:-finwar}
       RUST_LOG: info
     command: migrate
     depends_on:
@@ -40,7 +40,8 @@ services:
     ports:
       - "4444:4444"
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-finwar}:${POSTGRES_PASSWORD:-password}@timescaledb:5432/${POSTGRES_DB:-finwar}
+      FINWAR_MARKET_DATABASE_URL: postgresql://${POSTGRES_USER:-finwar}:${POSTGRES_PASSWORD:-password}@timescaledb:5432/${POSTGRES_DB:-finwar}
+      FINWAR_MARKET_TARGET_TICKER: NVDA
       RUST_LOG: info
     command: serve
     depends_on:

--- a/servers/rust-server/Cargo.toml
+++ b/servers/rust-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finwar-market"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Coding Kelps <contact@kelps.org>"]
 autotests = true
 categories = ["finance", "simulation"]

--- a/servers/rust-server/README.md
+++ b/servers/rust-server/README.md
@@ -89,3 +89,13 @@ or in powershell:
 ```powershell
 Invoke-RestMethod -Uri http://localhost:4444/api/enroll -Method POST -ContentType "application/json" -Body '{"name":"bot0"}'
 ```
+
+## Configuration
+
+| Name                                  | Description                                                           | Default                 |
+| :------------------------------------ | :-------------------------------------------------------------------- | :---------------------: |
+| FINWAR_MARKET_ADDR                    | The HTTP server address.                                              | `0.0.0.0`               |
+| FINWAR_MARKET_PORT                    | The HTTP server port                                                  | `4444`                  |
+| FINWAR_MARKET_INTERVAL_SECONDS        | The internal time passed (in seconds) in the Market each real second. | `60`                    |
+| FINWAR_MARKET_TARGET_SYMBOL           | The target stock symbol on which the Market simulation is based on.   | `AAPL`                  |
+| FINWAR_MARKET_DATABASE_URL            | The URL with authentication information of the backend database.      |                         |

--- a/servers/rust-server/src/cli.rs
+++ b/servers/rust-server/src/cli.rs
@@ -24,7 +24,8 @@ pub async fn run() -> Result<(), crate::error::Error> {
     match opts.command {
         Command::Serve => {
             let database_url =
-                std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+                std::env::var("FINWAR_MARKET_DATABASE_URL")
+                    .expect("FINWAR_MARKET_DATABASE_URL must be set");
 
             let db_connection = sea_orm::Database::connect(&database_url)
                 .await
@@ -34,7 +35,8 @@ pub async fn run() -> Result<(), crate::error::Error> {
         },
         Command::Migrate => {
             let database_url =
-                std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+                std::env::var("FINWAR_MARKET_DATABASE_URL")
+                    .expect("FINWAR_MARKET_DATABASE_URL must be set");
 
             let db_connection = sea_orm::Database::connect(&database_url)
                 .await

--- a/servers/rust-server/src/clock.rs
+++ b/servers/rust-server/src/clock.rs
@@ -28,7 +28,7 @@ impl MarketClock {
     }
 
     pub fn advance(&mut self, seconds: u64) {
-        self.current_time = self.current_time + Duration::from_secs(seconds * 60);
+        self.current_time = self.current_time + Duration::from_secs(seconds);
     }
 }
 

--- a/servers/rust-server/src/home.rs
+++ b/servers/rust-server/src/home.rs
@@ -33,7 +33,7 @@ fn calculate_ma(period: usize, data: &[Vec<f64>]) -> Vec<f64> {
 
 pub async fn chart(state: &AppState) -> Result<Chart, AppError> {
     let records = stocks_history::Entity::find()
-        .filter(stocks_history::Column::Symbol.eq("AAPL"))
+        .filter(stocks_history::Column::Symbol.eq(&state.target_symbol))
         .order_by_asc(stocks_history::Column::Time)
         .limit(300)
         .all(&state.db)

--- a/servers/rust-server/src/state.rs
+++ b/servers/rust-server/src/state.rs
@@ -30,16 +30,18 @@ pub struct AppState {
     pub starting_cash: f64,
     pub starting_assets: i32,
     pub clock: SharedClock,
+    pub target_symbol: String,
 }
 
 impl AppState {
-    pub async fn new(db: DatabaseConnection, clock: SharedClock) -> Result<Self, StateError> {
+    pub async fn new(db: DatabaseConnection, clock: SharedClock, target_symbol: String) -> Result<Self, StateError> {
         Ok(AppState {
             db,
             uuid_prefix_length: 18,
             starting_cash: 10000.0,
             starting_assets: 0,
             clock,
+            target_symbol,
         })
     }
 }

--- a/servers/rust-server/src/trade.rs
+++ b/servers/rust-server/src/trade.rs
@@ -102,6 +102,7 @@ async fn get_current_price(state: &AppState) -> Result<f64, AppError> {
     let current_time = state.clock.read().await.current_time();
     
     let stock = stocks_history::Entity::find()
+        .filter(stocks_history::Column::Symbol.eq(&state.target_symbol))
         .filter(stocks_history::Column::Time.lte(current_time))
         .order_by_desc(stocks_history::Column::Time)
         .one(&state.db)


### PR DESCRIPTION
Added FINWAR_MARKET_ADDR, FINWAR_MARKET_PORT, FINWAR_MARKET_TARGET_TICKER to the environment variables to configure the market API server.
Gave FINWAR_MARKET_ prefix to all environment variables and added a configuration section to the server README.md.
Also renamed TICK_INTERVAL_SECONDS into FINWAR_MARKET_TICK_RATE and reduced the minimal tick rate possible from 1 minute to 1 second.

Closes #49

BREAKING CHANGE: TICK_INTERVAL_SECONDS and DATABASE_URL have been renamed FINWAR_MARKET_TICK_RATE and FINWAR_MARKET_DATABASE_URL.
