### PR TITLE
Extend Market API configuration

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,5 +1,5 @@
 POSTGRES_USER=finwar
 POSTGRES_PASSWORD=password
 POSTGRES_DB=finwar
-DATABASE_URL=postgresql://finwar:password@localhost:5432/finwar
+FINWAR_MARKET_DATABASE_URL=postgresql://finwar:password@localhost:5432/finwar
 RUST_LOG=info

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,10 @@ services:
       context: ./servers/rust-server
       dockerfile: docker/Dockerfile
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-finwar}:${POSTGRES_PASSWORD:-password}@timescaledb:5432/${POSTGRES_DB:-finwar}
-      RUST_LOG: info
+      FINWAR_MARKET_DB_USER: ${POSTGRES_USER:-finwar}
+      FINWAR_MARKET_DB_PASSWORD: ${POSTGRES_PASSWORD:-password}
+      FINWAR_MARKET_DB_HOST: timescaledb
+      FINWAR_MARKET_DB_NAME: ${POSTGRES_DB:-finwar}
     command: migrate
     depends_on:
       timescaledb:
@@ -40,8 +42,11 @@ services:
     ports:
       - "4444:4444"
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-finwar}:${POSTGRES_PASSWORD:-password}@timescaledb:5432/${POSTGRES_DB:-finwar}
-      RUST_LOG: info
+      FINWAR_MARKET_DB_USER: ${POSTGRES_USER:-finwar}
+      FINWAR_MARKET_DB_PASSWORD: ${POSTGRES_PASSWORD:-password}
+      FINWAR_MARKET_DB_HOST: timescaledb
+      FINWAR_MARKET_DB_NAME: ${POSTGRES_DB:-finwar}
+      FINWAR_MARKET_TRACKED_TICKER: AAPL
     command: serve
     depends_on:
       migration:
@@ -51,7 +56,7 @@ services:
     image: docker.io/library/busybox:stable-uclibc
     command: ["sh", "-c", "tail -f /dev/null"]
     healthcheck:
-      test: ["CMD-SHELL", "wget -q --spider --tries=1 http://rust-server:4444/api/time || exit 1"]
+      test: ["CMD-SHELL", "wget -q --spider --tries=1 http://rust-server:4444/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/servers/rust-server/Cargo.lock
+++ b/servers/rust-server/Cargo.lock
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.51"
+version = "4.5.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
+checksum = "aa8120877db0e5c011242f96806ce3c94e0737ab8108532a76a3300a01db2ab8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.51"
+version = "4.5.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
+checksum = "02576b399397b659c26064fbc92a75fede9d18ffd5f80ca1cd74ddab167016e1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1081,7 +1081,7 @@ checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
 
 [[package]]
 name = "finwar-market"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "askama",
  "async-std",

--- a/servers/rust-server/Cargo.toml
+++ b/servers/rust-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finwar-market"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Coding Kelps <contact@kelps.org>"]
 autotests = true
 categories = ["finance", "simulation"]

--- a/servers/rust-server/README.md
+++ b/servers/rust-server/README.md
@@ -45,7 +45,7 @@ sea-orm-cli migrate reset
 
 ### Environment Setup
 
-- Set `DATABASE_URL=postgres://finwar:password@localhost/finwar` as an env variable or in a .env
+- Set `FINWAR_MARKET_DB_USER=finwar`, `FINWAR_MARKET_DB_PASSWORD=password`, and `FINWAR_MARKET_DB_NAME=finwar` as an env variable or in a .env
 - Default server runs on `0.0.0.0:4444`
 - Stock data loaded from `./local/data/Stocks/` directory
 
@@ -68,7 +68,7 @@ docker build -t finwar-rust-server -f ./docker/Dockerfile .
 **Run only the server container:**
 
 ```bash
-docker run -p 4444:4444 -e DATABASE_URL=postgresql://finwar:password@host.docker.internal:5432/finwar finwar-rust-server
+docker run -p 4444:4444 -e FINWAR_MARKET_DB_USER=finwar FINWAR_MARKET_DB_PASSWORD=password FINWAR_MARKET_DB_NAME=finwar finwar-rust-server
 ```
 
 **Or use docker-compose (recommended):**
@@ -89,3 +89,20 @@ or in powershell:
 ```powershell
 Invoke-RestMethod -Uri http://localhost:4444/api/enroll -Method POST -ContentType "application/json" -Body '{"name":"bot0"}'
 ```
+
+## Configuration
+
+| Environment Variable                  | Command Line.        | Description                                                                  | Default                 |
+| :------------------------------------ | :------------------  | :--------------------------------------------------------------------------- | :---------------------: |
+| `FINWAR_MARKET_LOG_LEVEL`             | `--log-level`        | The log level of the application.                                            | `info`                  |
+| `FINWAR_MARKET_HOST`                  | `--host`             | The HTTP server address.                                                     | `0.0.0.0`               |
+| `FINWAR_MARKET_PORT`                  | `--port`             | The HTTP server port                                                         | `4444`                  |
+| `FINWAR_MARKET_INTERVAL_SECONDS`      | `--interval-seconds` | The internal time passed (in seconds) in the Market each real second.        | `60`                    |
+| `FINWAR_MARKET_TRACKED_SYMBOL`        | `--tracked-symbols`  | The tracked stock ticker symbol on which the Market simulation is based on.  | `AAPL`                  |
+| `FINWAR_MARKET_DB_USER`               | `--db-user`          | The username used for the database authentication.                           |                         |
+| `FINWAR_MARKET_DB_USER_FILE`          | `--db-user-file`     | The path of the file containing the database auth username.                  |                         |
+| `FINWAR_MARKET_DB_PASSWORD`           | `--db-password`      | The password used for the database authentication.                           |                         |
+| `FINWAR_MARKET_DB_PASSWORD_FILE`      | `--db-password-file` | The path of the file containing the database auth password.                  |                         |
+| `FINWAR_MARKET_DB_HOST`               | `--db-host`          | The host or address of the database to connect to.                           | `localhost`             |
+| `FINWAR_MARKET_DB_PORT`               | `--db-port`          | The port of the database to connect to.                                      | `5432`                  |
+| `FINWAR_MARKET_DB_NAME`               | `--db-name`          | The name of the database to connect to.                                      | `postgres`              |

--- a/servers/rust-server/src/clock.rs
+++ b/servers/rust-server/src/clock.rs
@@ -28,7 +28,7 @@ impl MarketClock {
     }
 
     pub fn advance(&mut self, seconds: u64) {
-        self.current_time = self.current_time + Duration::from_secs(seconds * 60);
+        self.current_time = self.current_time + Duration::from_secs(seconds);
     }
 }
 

--- a/servers/rust-server/src/config.rs
+++ b/servers/rust-server/src/config.rs
@@ -1,0 +1,133 @@
+use crate::cli::{Args, Commands};
+use std::fs;
+
+#[derive(Debug, Clone)]
+pub struct Config {
+  pub server: ServerConfig,
+  pub database: DatabaseConfig,
+  pub log: LogConfig,
+  pub tracked_symbol: String,
+  pub interval_seconds: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+  pub host: String,
+  pub port: u16,
+}
+
+#[derive(Debug, Clone)]
+pub struct DatabaseConfig {
+  pub user: Sensitive<String>,
+  pub password: Sensitive<String>,
+  pub host: String,
+  pub port: u16,
+  pub name: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct LogConfig {
+  pub level: String,
+}
+
+// Wrapper type for sensitive data that masks itself when printed
+#[derive(Clone)]
+pub struct Sensitive<T>(T);
+
+impl<T> Sensitive<T> {
+  fn new(value: T) -> Self {
+    Sensitive(value)
+  }
+  
+  pub fn expose(&self) -> &T {
+    &self.0
+  }
+}
+
+impl<T> std::fmt::Debug for Sensitive<T> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "***")
+  }
+}
+
+impl<T> std::fmt::Display for Sensitive<T> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "***")
+  }
+}
+
+impl Config {
+  pub fn from_args(
+    args: Args,
+  ) -> Self {
+    match args.command {
+      Commands::Serve {
+        host,
+        port,
+        db_user,
+        db_user_file,
+        db_password,
+        db_password_file,
+        db_host,
+        db_port,
+        db_name,
+        tracked_symbol,
+        interval_seconds,
+      } => {
+        Config {
+          server: ServerConfig { host, port },
+          database: DatabaseConfig {
+            user: Sensitive::new(db_user.unwrap_or_else(|| {
+                fs::read_to_string(db_user_file.expect("missing database user secret file path"))
+                .expect("failed to read database user secret file").trim_end().to_string()
+            })),
+            password: Sensitive::new(db_password.unwrap_or_else(|| {
+                fs::read_to_string(db_password_file.expect("missing database user secret file path"))
+                .expect("failed to read database password secret file").trim_end().to_string()
+            })),
+            host: db_host,
+            port: db_port,
+            name: db_name,
+          },
+          log: LogConfig {
+            level: args.log_level,
+          },
+          tracked_symbol: tracked_symbol,
+          interval_seconds: interval_seconds,
+        }
+      },
+      Commands::Migrate {
+        db_user,
+        db_user_file,
+        db_password,
+        db_password_file,
+        db_host,
+        db_port,
+        db_name,
+      } => {
+        Config {
+          server: ServerConfig { host: String::from(""), port: 0 },
+          database: DatabaseConfig {
+            user: Sensitive::new(db_user.unwrap_or_else(|| {
+                fs::read_to_string(db_user_file.expect("missing database user secret file path"))
+                .expect("failed to read database user secret file").trim_end().to_string()
+            })),
+            password: Sensitive::new(db_password.unwrap_or_else(|| {
+                fs::read_to_string(db_password_file.expect("missing database user secret file path"))
+                .expect("failed to read database password secret file").trim_end().to_string()
+            })),
+            host: db_host,
+            port: db_port,
+            name: db_name,
+          },
+          log: LogConfig {
+            level: args.log_level,
+          },
+          tracked_symbol: String::from(""),
+          interval_seconds: 0,
+        }
+      }
+    }
+
+  }
+}

--- a/servers/rust-server/src/home.rs
+++ b/servers/rust-server/src/home.rs
@@ -33,7 +33,7 @@ fn calculate_ma(period: usize, data: &[Vec<f64>]) -> Vec<f64> {
 
 pub async fn chart(state: &AppState) -> Result<Chart, AppError> {
     let records = stocks_history::Entity::find()
-        .filter(stocks_history::Column::Symbol.eq("AAPL"))
+        .filter(stocks_history::Column::Symbol.eq(&state.tracked_symbol))
         .order_by_asc(stocks_history::Column::Time)
         .limit(300)
         .all(&state.db)

--- a/servers/rust-server/src/state.rs
+++ b/servers/rust-server/src/state.rs
@@ -30,16 +30,18 @@ pub struct AppState {
     pub starting_cash: f64,
     pub starting_assets: i32,
     pub clock: SharedClock,
+    pub tracked_symbol: String,
 }
 
 impl AppState {
-    pub async fn new(db: DatabaseConnection, clock: SharedClock) -> Result<Self, StateError> {
+    pub async fn new(db: DatabaseConnection, clock: SharedClock, tracked_symbol: String) -> Result<Self, StateError> {
         Ok(AppState {
             db,
             uuid_prefix_length: 18,
             starting_cash: 10000.0,
             starting_assets: 0,
             clock,
+            tracked_symbol,
         })
     }
 }

--- a/servers/rust-server/src/trade.rs
+++ b/servers/rust-server/src/trade.rs
@@ -102,6 +102,7 @@ async fn get_current_price(state: &AppState) -> Result<f64, AppError> {
     let current_time = state.clock.read().await.current_time();
     
     let stock = stocks_history::Entity::find()
+        .filter(stocks_history::Column::Symbol.eq(&state.tracked_symbol))
         .filter(stocks_history::Column::Time.lte(current_time))
         .order_by_desc(stocks_history::Column::Time)
         .one(&state.db)


### PR DESCRIPTION
Extended the configuration of the application to make the server host, port, and tracked symbol configurable.
Environment variables can now be overridden from command line arguments.
Gave FINWAR_MARKET_ prefix to all environment variables and added a configuration section to the server README.md.
Added an /health route to check server status.

Closes https://github.com/coding-kelps/finwar/issues/45
Closes https://github.com/coding-kelps/finwar/issues/49
Closes https://github.com/coding-kelps/finwar/issues/51

BREAKING CHANGE: All environment variables have now the FINWAR_MARKET_ prefix. The DATABASE_URL variable have been splitted into DB_USER, DB_PASSWORD, DB_HOST, DB_PORT, and DB_NAME.
